### PR TITLE
Define numpy as an install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 import sys
 from setuptools import find_packages, setup
 
-install_requires = ['python-dateutil>=2.2']
-
-try: import numpy
-except ImportError: install_requires.append('numpy')
+install_requires = ['python-dateutil>=2.2', 'numpy']
 
 if sys.version_info[0] < 3:
     import unittest


### PR DESCRIPTION
On a project I am working on, we are using `pip-compile` to generate the `requirements.txt` for an application. 

Currently this generates different results depending on whether or not numpy is installed on the system.

Shouldn't `numpy` just be part of the `install_requires` list? That is the old code is only stating the `numpy` is an explicit requirement if is not installed. If it is installed, wouldn't this make `numpy` an implicit install requirement?